### PR TITLE
fix: misplaced comma

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -151,8 +151,8 @@ module Helper
           :name0 => pair[0],
           :name1 => pair[1],
           :index0 => index_map[pair[0]],
-          :index1 => index_map[pair[1]]
-          :weight => weight,
+          :index1 => index_map[pair[1]],
+          :weight => weight
         }
       end
     end  

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -16,7 +16,7 @@ module Helper
       else
         adds, deletes, filename = line.split(/\t/)
         
-        next if ! (filename =~ /\.(scala|rb|sh|java|js|clj)(}*)$/)
+        next if ! (filename =~ /\.(scala|rb|sh|java|js|jsx|ts|clj)(}*)$/)
         next if filename =~ /lambda/
         next if filename =~ /generated/
 
@@ -111,7 +111,7 @@ module Helper
         adds, deletes, filename = line.split(/\t/)
         
         # next if ! (filename =~ /app/)
-        next if ! (filename =~ /\.(scala|rb|sh|java|js|clj)(}*)$/)
+        next if ! (filename =~ /\.(scala|rb|sh|java|js|jsx|ts|clj)(}*)$/)
         next if filename =~ /lambda/
         next if filename =~ /generated/
 


### PR DESCRIPTION
was getting the following 
```
jay@ubuntu:~/churn-charts$ ./app.rb 
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': /home/jay/churn-charts/lib/helper.rb:155: syntax error, unexpected tSYMBEG, expecting '}' (SyntaxError)
          :weight => weight,
           ^
/home/jay/churn-charts/lib/helper.rb:163: syntax error, unexpected end-of-input, expecting keyword_end
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./app.rb:6:in `<main>'
```