### PR TITLE
helper.rb: Remove syntax error

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -151,7 +151,7 @@ module Helper
           :name0 => pair[0],
           :name1 => pair[1],
           :index0 => index_map[pair[0]],
-          :index1 => index_map[pair[1]]
+          :index1 => index_map[pair[1]],
           :weight => weight,
         }
       end


### PR DESCRIPTION
unexpected tSYMBEG, expecting '}' (SyntaxError)
          :weight => weight,
          ^
missing comma